### PR TITLE
CacheLines mutability

### DIFF
--- a/remotestruct/cache.py
+++ b/remotestruct/cache.py
@@ -52,7 +52,7 @@ class CacheLine(object):
 		
 		assert rng.span() == len(data)
 		self.lastread = self.lastupdate = time()
-		self.data = data
+		self.data = bytearray(data)
 		self.range = rng
 		
 	def write(self, rng, data):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
 	# the version across setup.py and the project code, see
 	# http://packaging.python.org/en/latest/tutorial.html#version
 	description='Ctypes Register Bitfields',
-	version='0.3.1',
+	version='0.3.2',
 	
 	long_description=long_description,
 


### PR DESCRIPTION
Under some circumstances I still don't quite understand, it was possible for a CacheLine to get a bytes .data object instead of a bytearray, when the update method was called.  Update now forces the data to a bytearray.